### PR TITLE
Add trace toggle to build scripts

### DIFF
--- a/releases/build-tools/build.sh
+++ b/releases/build-tools/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 #  Copyright 2018 phData Inc.
 # 
@@ -17,6 +17,9 @@
 
 #shell options 
 set -e
+if [ "${trace-}" = "true" ]; then 
+  set -x
+fi
 
 # variables/ labels
 prefix="phData-CFCI build: "

--- a/releases/build-tools/gitlab_build.sh
+++ b/releases/build-tools/gitlab_build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash 
 
 #  Copyright 2018 phData Inc.
 # 
@@ -17,6 +17,9 @@
 
 #shell options 
 set -e
+if [ "${trace-}" = "true" ]; then 
+  set -x
+fi
 
 # variables/ labels
 prefix="phData-CFCI build:"

--- a/releases/build-tools/gitlab_jenkins_build.sh
+++ b/releases/build-tools/gitlab_jenkins_build.sh
@@ -17,6 +17,9 @@
 
 #shell options 
 set -e
+if [ "${trace-}" = "true" ]; then 
+  set -x
+fi
 
 # variables/ labels
 delete_this="TEST"


### PR DESCRIPTION
Add the ability to toggle trace output. Tracing is sometimes useful for debugging, but can also be harmful when it obscures other relevant output. Users can enable trace output, i.e. `set -x`, by setting the environment variable `trace` to `true`, otherwise it will not be set.