### PR TITLE
--output json added to read ChangeSet output in Json

### DIFF
--- a/releases/build-tools/build.sh
+++ b/releases/build-tools/build.sh
@@ -743,9 +743,9 @@ changeset_action() {
     do
         switch_set_e
         if [ "$1" = "describe" ]; then
-            sceptre --no-colour --ignore-dependencies describe change-set -v $2 $3 &> output
+            sceptre --no-colour --output json --ignore-dependencies describe change-set -v $2 $3 &> output
         elif [ "$1" = "delete" ]; then
-            sceptre --no-colour describe change-set $2 $3 &> output
+            sceptre --no-colour --output json describe change-set $2 $3 &> output
         fi
         switch_set_e
         if grep "Traceback " output ; then

--- a/releases/build-tools/gitlab_build.sh
+++ b/releases/build-tools/gitlab_build.sh
@@ -741,9 +741,9 @@ changeset_action() {
     do
         switch_set_e
         if [ "$1" = "describe" ]; then
-            sceptre --no-colour --ignore-dependencies describe change-set -v $2 $3 &> output
+            sceptre --no-colour --output json --ignore-dependencies describe change-set -v $2 $3 &> output
         elif [ "$1" = "delete" ]; then
-            sceptre --no-colour describe change-set $2 $3 &> output
+            sceptre --no-colour --output json describe change-set $2 $3 &> output
         fi
         switch_set_e
         if grep "Traceback " output ; then

--- a/releases/build-tools/gitlab_jenkins_build.sh
+++ b/releases/build-tools/gitlab_jenkins_build.sh
@@ -736,9 +736,9 @@ changeset_action() {
     do
         switch_set_e
         if [ "$1" = "describe" ]; then
-            sceptre --no-colour --ignore-dependencies describe change-set -v $2 $3 &> output
+            sceptre --no-colour --output json --ignore-dependencies describe change-set -v $2 $3 &> output
         elif [ "$1" = "delete" ]; then
-            sceptre --no-colour describe change-set $2 $3 &> output
+            sceptre --no-colour --output json describe change-set $2 $3 &> output
         fi
         switch_set_e
         if grep "Traceback " output ; then


### PR DESCRIPTION
In latest version of Secptre (2.4.0) change-set default output format is returning as a string compare to  2.2.1 (returning in json by default)

"--output json" added to read output data in json for ChangeSet describe and delete operation to avoid build failures.

example:
sceptre --no-colour --output json --ignore-dependencies describe change-set -v $2 $3 &> output
sceptre --no-colour --output json describe change-set $2 $3 &> output